### PR TITLE
Use generic return type for runWithPermissions functions.

### DIFF
--- a/quickpermissions-kotlin/src/main/java/com/livinglifetechway/quickpermissions_kotlin/PermissionsManager.kt
+++ b/quickpermissions-kotlin/src/main/java/com/livinglifetechway/quickpermissions_kotlin/PermissionsManager.kt
@@ -145,7 +145,7 @@ private fun <T> runWithPermissionsHandler(target: Any?, permissions: Array<out S
 
             // start requesting permissions for the first time
             permissionCheckerFragment.requestPermissionsFromUser()
-            return result ?: Unit as T
+            return result as T
         }
     } else {
         // context is null

--- a/quickpermissions-kotlin/src/main/java/com/livinglifetechway/quickpermissions_kotlin/PermissionsManager.kt
+++ b/quickpermissions-kotlin/src/main/java/com/livinglifetechway/quickpermissions_kotlin/PermissionsManager.kt
@@ -145,7 +145,7 @@ private fun <T> runWithPermissionsHandler(target: Any?, permissions: Array<out S
 
             // start requesting permissions for the first time
             permissionCheckerFragment.requestPermissionsFromUser()
-            return result!!
+            return result ?: Unit as T
         }
     } else {
         // context is null


### PR DESCRIPTION
This can be useful to preserve the original function's return type.
My use case:
```
interface InterfaceWithUnitMethod{
        fun unitMethod()
}
class MyFragment() : Fragment(), InterfaceWithUnitMethod{
       override fun unitMethod() = runWithPermissions(...){
                ...
       }
}
```
The `override` will only work if the return type matches the `interface`'s, that is, `Unit`. Therefore, the previous `Any?` return type won't work in this scenario.